### PR TITLE
 The following 4 issues have been resolved.

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -27,7 +27,7 @@ Minimizationスクリプトを実行するためには以下のコマンド類�
 1. minimizeを行うカーネルソースツリーのルートディレクトリに移動してください。  
 例:
 ```bash
-$ cd linux-4.3.3
+$ cd linux-4.4.1
 ```
 
 2. `minimize.py`スクリプトをカーネルツリーのルートディレクトリにコピーしてください。
@@ -85,8 +85,8 @@ Minimization結果の統計情報と差分情報が出力ディレクトリに `
 `minimize.py` スクリプトを `diffstat.log` へのファイルパスを引数に直接実行すると、Minimizationサマリ情報を以下のように出力します。  
 ```bash
 $ ./minimize.py ../minimized-busybox/diffstat.log 
-339 out of 505 C files have been minimized.
-Unused 25695 lines(14% of the original C code) have been removed.
+296 out of 505 compiled C files have been minimized.
+Unused 20460 lines(11% of the original C code) have been removed.
 ```
 
 ## Verification for the minimized built binary
@@ -95,17 +95,18 @@ MinimizeしたBusyBoxソースコードを元のBusyBoxプロジェクトに対�
 生成される`busybox_unstripped.out` および `busybox_unstripped.out`は、minimize前にビルドしたものと全く同一(md5sumが一致)となります。  
 実行ファイル `busybox` および `busybox_unstripped` についてはタイムスタンプ等が異なりバイナリは一致しませんが、`objdump -d busybox` で逆アセンブルするとその結果はminimize処理前のものと一致します。  
   
-Linux Kernelに対しては vmlinux.o の逆アセンブル結果 `objdump -d vmlinux.o` がminimize前後で一致することを確認しています。  
-minimize後のビルド成功を確認した設定はLinux Kernelで `allnoconfig` のみ、BusyBoxに対しては `allnoconfig` と `defconfig` のみです。  
+Linux Kernelに対しては vmlinux.o の逆アセンブル結果 `objdump -d vmlinux.o` がminimize前後で一致することを`allnoconfig`条件下で確認しています。  
+minimize後のビルド成功を確認した設定はLinux Kernelで `allnoconfig` 、`defconfig`(x86)、そしてクロスビルド環境の`omap2plus_defconfig`(arm-linux-gnueabi)です。  
+BusyBoxに対しては `allnoconfig` と `defconfig` でminimized後のソースのビルド成功を確認しています。
   
 ## TODOs
 1. CMakeなど他のビルドシステムでも適用できるよう拡張する
 2. `--with-spatch`オプションなどのように、検証ツールを同時に実行できるようにする
-3. Linux Kernel/BusyBoxともに他のconfigでも適用できることを確認する
+3. Linux Kernel/BusyBoxともに他のconfigまたはアーキテクチャでも適用できることを確認する
 
 ## Version compatibility
 * Python 2.x と 3.x のいずれでもそのまま実行可能です。
-* Linux Kernel は 4.0.7 および 4.3.3 に対して適用できることを確認しました。                                                                      
+* Linux Kernel は 4.0.7, 4.3.3, 4.4.1 に対して適用できることを確認しました。
 * BusyBox は 1.24.1 に対して適用できることを確認しました。
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The minimization script requires the following commands working in the host mach
 1. Navigate to your kernel tree directory.  
 example:
 ```bash
-$ cd linux-4.3.3
+$ cd linux-4.4.1
 ```
 
 2. copy `minimize.py` to your kernel tree directory.
@@ -89,8 +89,8 @@ There is a minimization summary info available. In the minimized tree directory,
 If you run `minimize.py` with the filepath of `diffstat.log`, it will display summary info like this.  
 ```bash
 $ ./minimize.py ../minimized-busybox/diffstat.log 
-339 out of 505 C files have been minimized.
-Unused 25695 lines(14% of the original C code) have been removed.
+296 out of 505 compiled C files have been minimized.
+Unused 20460 lines(11% of the original C code) have been removed.
 ```
 
 ## Verification for the minimized built binary
@@ -100,17 +100,19 @@ Among the minimized built products, `busybox_unstripped.out` and `busybox_unstri
 The executables `busybox` and `busybox_unstripped` differ in some points(build time stamp etc),  
 but the disassembled code (output of `objdump -d busybox`) exactly matches with the original ones also.  
   
-For the Linux Kernel, we confirmed `objdump -d vmlinux.o` exatcly matches between the minimized and the original. Confirmed config is only `allnoconfig`.
-Other kernel configs are yet to determine.  
+For the Linux Kernel, we confirmed `objdump -d vmlinux.o` exatcly matches between the minimized and the original built product in `allnoconfig` condition.  
+For compilation of the minimized Kernel Tree, `allnoconfig`, `defconfig`(x86), and cross-environment `omap2plus_defconfig`(arm-linux-gnueabi) are confirmed successful.  
+For compilation of the minimized BusyBox, `allnoconfig` and `defconfig`(x86) are confirmed successful.  
+Other kernel configs or architectures are yet to be determined.  
   
 ## TODOs
 1. Consider extending this technique to other build system such as CMake.
 2. Combine analysis execution at one time (like `--with-spatch` option).
-3. Try other kernel/busybox config.
+3. Try other kernel/busybox config or othre architectures.
 
 ## Version compatibility
 * Works on either Python 2.x or 3.x without any modification. 
-* For Linux Kernel, we've confirmed 4.0.7 and 4.3.3 are applicable.
+* For Linux Kernel, we've confirmed 4.0.7, 4.3.3, and 4.4.1 are applicable.
 * For BusyBox, we've confirmed 1.24.1 is applicable.
 
 


### PR DESCRIPTION
1: Open file as binary mode(rb, rw) and manipulate them as byte array in order to handle undecodable bytes.
2: Exceptionally just copy "arch/x86/boot/video-_" and "lib/decompress__" files as are without deleting #ifdef/#ifndef
   because they are referred from multiple location with different -D configurations.
3: Cross-compilation supported, confirmed that Linux Kernel(4.4.1) tree with omap2plus_defconfig(arm-linux-gnueabi) can be minimized.
   Also the minimized tree of omap2plus_defconfig(ARM) is confirmed to be compilable.
4: Some bug-fixes for string manupulatation, now minimized tree of the defconfig Linux Kernel is confirmed to be compilable.

Signed-off-by: Kotaro Hashimoto kotaro.hashimoto.jv@hitachi.com
