### PR TITLE
BugFix: Cannot identify #include string when the line starts with white space

### DIFF
--- a/minimize.py
+++ b/minimize.py
@@ -265,7 +265,7 @@ def stripHeaders(mindir, target):
         lineElements = line.split()
 
         # look for linemarkers from the Preprocessor Output in order to remove expanded header file contents
-        if len(lineElements) >= 3 and line.startswith(b'# '):
+        if len(lineElements) >= 3 and line.strip().startswith(b'# '):
             if lineElements[1].isdigit() and lineElements[2][:1] == lineElements[2][-1:] == b'\"':
 
                 # look for #include sentence to be restored in the original C file


### PR DESCRIPTION
Bugfix:
When #include line started with white space, the minimize.py script went into infinite loop.
Fixed the #include search logic by ignoring white space at the beginning of lines.
