### PR TITLE
polishment in filepath expression in the output file minimize.patch

### DIFF
--- a/minimize.py
+++ b/minimize.py
@@ -217,6 +217,10 @@ def restoreHeaderInclude(mindir, target, strippedLines):
         # regular case, let the strippedLines match the original file, then resotre them.
         restoreContents(strippedLines, mindir, target)
 
+    # avoid multiple recording in minimize.patch
+    if 'init/version.c' in target:
+        return
+
     # write diff statistics for the minimization process
     if (os.system('diff -u ' + target + ' ' + mindir + target + ' > ' + mindir + 'tmp') >> 8) > 1 or \
        (os.system('diff -u ' + target + ' ' + mindir + target + '| diffstat -p 2 >> ' + mindir + 'diffstat.log') >> 8) != 0:

--- a/minimize.py
+++ b/minimize.py
@@ -218,7 +218,7 @@ def restoreHeaderInclude(mindir, target, strippedLines):
         restoreContents(strippedLines, mindir, target)
 
     # write diff statistics for the minimization process
-    if (os.system('diff -u ' + target + ' ' + mindir + target + ' >> ' + mindir + '_minimize.patch') >> 8) > 1 or \
+    if (os.system('diff -u ' + target + ' ' + mindir + target + ' > ' + mindir + 'tmp') >> 8) > 1 or \
        (os.system('diff -u ' + target + ' ' + mindir + target + '| diffstat -p 2 >> ' + mindir + 'diffstat.log') >> 8) != 0:
         display('Failed to run diff and diffstat commands.', 'err')
         display('Please install diff and diffstat utilities in the host machine.', 'err')
@@ -230,8 +230,8 @@ def restoreHeaderInclude(mindir, target, strippedLines):
 
         
     # polish relative file paths expression in minimize.patch content
-    fp = open(mindir + 'minimize.patch', 'w')
-    for line in open(mindir + '_minimize.patch'):
+    fp = open(mindir + 'minimize.patch', 'a')
+    for line in open(mindir + 'tmp'):
     
         if line.startswith('---') or line.startswith('+++'):
         
@@ -248,7 +248,7 @@ def restoreHeaderInclude(mindir, target, strippedLines):
         fp.write(line)
     
     fp.close()
-    os.remove(mindir + '_minimize.patch')
+    os.remove(mindir + 'tmp')
 
         
 # check directory existence, make the base directory, return the directory path


### PR DESCRIPTION
The file path string in minimize.patch had contained inappropriate relative form, where patch command could not accept to apply.

This commit rewrites the file path in minimize.py in a way patch command works correctly.
